### PR TITLE
Enable Python3 support and fix a typo

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 
-- name: Cteate nsswitch.conf file
+- name: Create nsswitch.conf file
   template:
     src: nsswitch.conf.j2
     dest: "{{ nsswitch_file_location }}"

--- a/templates/nsswitch.conf.j2
+++ b/templates/nsswitch.conf.j2
@@ -1,6 +1,6 @@
 {{ ansible_managed | comment }}
 
-{% for key, val in nsswitch_config.iteritems() | sort %}
+{% for key, val in nsswitch_config.items() | sort %}
   {%- if val | length > 0 -%}
     {{ key }}: {{ val | join(' ') }}{{ "\n" }}
   {%- endif %}


### PR DESCRIPTION
Python3 doesn't support dict.iteritems() so the template in this role fails to run on Ansible installations that use Python3. It was replaced with dict.items() which also works in Python2 so this change should allow the role to work everywhere.
I also found a typo in the name of the task so I fixed that too.